### PR TITLE
Enh fix expense advance clearing

### DIFF
--- a/account_cancel_with_reversal/__openerp__.py
+++ b/account_cancel_with_reversal/__openerp__.py
@@ -19,6 +19,7 @@ when it cancelled.
     ],
     'demo': [],
     'data': [
+        'wizard/cancel_reason_view.xml',
         'wizard/account_move_reverse_view.xml',
         'views/account_invoice_view.xml',
         'views/account_voucher_view.xml'

--- a/account_cancel_with_reversal/views/account_invoice_view.xml
+++ b/account_cancel_with_reversal/views/account_invoice_view.xml
@@ -15,7 +15,10 @@
                     />
                 </xpath>
                 <xpath expr="//button[@name='invoice_cancel']" position="attributes">
-                    <attribute name="states">draft,proforma2</attribute>
+                    <attribute name="invisible">True</attribute>
+                </xpath>
+                <xpath expr="//button[@name='invoice_cancel']" position="before">
+                    <button name="%(action_account_invoice_cancel)d" type="action" states="draft,proforma2" string="Cancel Invoice" groups="account.group_account_invoice"/>
                 </xpath>
                 <xpath expr="//button[@name='action_cancel_draft']" position="attributes">
                     <attribute name="invisible">True</attribute>
@@ -44,6 +47,12 @@
                             class="oe_highlight" 
                             states="open"
                     />
+                </xpath>
+                <xpath expr="//button[@name='invoice_cancel']" position="attributes">
+                    <attribute name="invisible">True</attribute>
+                </xpath>
+                <xpath expr="//button[@name='invoice_cancel']" position="before">
+                    <button name="%(action_account_invoice_cancel)d" type="action" states="draft,proforma2" string="Cancel Invoice" groups="account.group_account_invoice"/>
                 </xpath>
                 <xpath expr="//button[@name='action_cancel_draft']" position="attributes">
                     <attribute name="invisible">True</attribute>

--- a/account_cancel_with_reversal/views/account_voucher_view.xml
+++ b/account_cancel_with_reversal/views/account_voucher_view.xml
@@ -20,6 +20,14 @@
                 <xpath expr="//button[@name='action_cancel_draft']" position="attributes">
                     <attribute name="invisible">True</attribute>
                 </xpath>
+                
+                <xpath expr="//header/button[2]" position="attributes">
+                    <attribute name="invisible">True</attribute>
+                </xpath>
+                <xpath expr="//header/button[2]" position="before">
+                    <button name="%(action_voucher_cancel)d" type="action" states="draft,proforma" string="Cancel Receipt" />
+                </xpath>
+                
                 <xpath expr="//field[@name='audit']" position="after">
                     <field name="cancel_move_id"/>
                 </xpath>
@@ -54,6 +62,16 @@
                 <xpath expr="//button[@name='action_cancel_draft']" position="attributes">
                     <attribute name="invisible">True</attribute>
                 </xpath>
+                
+                <xpath expr="//header/button[2]" position="attributes">
+                    <attribute name="invisible">True</attribute>
+                </xpath>
+                <xpath expr="//header/button[2]" position="before">
+                    <button name="%(action_voucher_cancel)d" 
+                            type="action" states="draft,proforma" string="Cancel Voucher"
+                            invisible="context.get('line_type', False)"/>
+                </xpath>
+                
                 <xpath expr="//field[@name='number']" position="after">
                     <field name="cancel_move_id"/>
                 </xpath>

--- a/account_cancel_with_reversal/wizard/__init__.py
+++ b/account_cancel_with_reversal/wizard/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from . import account_move_reverse
+from . import cancel_reason
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_cancel_with_reversal/wizard/account_move_reverse.py
+++ b/account_cancel_with_reversal/wizard/account_move_reverse.py
@@ -52,7 +52,7 @@ class AccountMoveReversal(models.TransientModel):
                 move_line_prefix=form['move_line_prefix'],
                 )
             invoice.write({'cancel_move_id': reverse_move_id[0],
-                           'cancel_reason_txt': form['cancel_reason_txt'],})
+                           'cancel_reason_txt': form['cancel_reason_txt'], })
             # cancel invoice
             invoice.signal_workflow('invoice_cancel')
             reversed_move_ids.extend(reverse_move_id)
@@ -85,7 +85,7 @@ class AccountMoveReversal(models.TransientModel):
                 move_line_prefix=form['move_line_prefix'],
                 )
             voucher.write({'cancel_move_id': reverse_move_id[0],
-                           'cancel_reason_txt': form['cancel_reason_txt'],})
+                           'cancel_reason_txt': form['cancel_reason_txt'], })
             voucher.cancel_voucher()
             reversed_move_ids.extend(reverse_move_id)
 

--- a/account_cancel_with_reversal/wizard/cancel_reason.py
+++ b/account_cancel_with_reversal/wizard/cancel_reason.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Author: Guewen Baconnier
+#    Copyright 2013 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from openerp import models, fields, api
+
+
+class AccountInvoiceCancel(models.TransientModel):
+
+    """ Ask a reason for the account invoice cancellation."""
+    _name = 'account.invoice.cancel'
+    _description = __doc__
+
+    cancel_reason_txt = fields.Char(
+        string="Reason",
+        readonly=False)
+
+    @api.one
+    def confirm_cancel(self):
+        act_close = {'type': 'ir.actions.act_window_close'}
+        invoice_ids = self._context.get('active_ids')
+        if invoice_ids is None:
+            return act_close
+        assert len(invoice_ids) == 1, "Only 1 sale ID expected"
+        invoice = self.env['account.invoice'].browse(invoice_ids)
+        invoice.cancel_reason_txt = self.cancel_reason_txt
+        invoice.signal_workflow('invoice_cancel')
+        return act_close
+
+
+class AccountVoucherCancel(models.TransientModel):
+
+    """ Ask a reason for the account voucher cancellation."""
+    _name = 'account.voucher.cancel'
+    _description = __doc__
+
+    cancel_reason_txt = fields.Char(
+        string="Reason",
+        readonly=False)
+
+    @api.one
+    def confirm_cancel(self):
+        act_close = {'type': 'ir.actions.act_window_close'}
+        voucher_ids = self._context.get('active_ids')
+        if voucher_ids is None:
+            return act_close
+        assert len(voucher_ids) == 1, "Only 1 voucher ID expected"
+        voucher = self.env['account.voucher'].browse(voucher_ids)
+        voucher.cancel_reason_txt = self.cancel_reason_txt
+        voucher.signal_workflow('cancel_voucher')
+        return act_close

--- a/account_cancel_with_reversal/wizard/cancel_reason_view.xml
+++ b/account_cancel_with_reversal/wizard/cancel_reason_view.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+        <record id="view_account_invoice_cancel" model="ir.ui.view">
+            <field name="name">Reason for the cancellation</field>
+            <field name="model">account.invoice.cancel</field>
+            <field name="arch" type="xml">
+             <form string="Reason for the cancellation" version="7.0">
+                <p class="oe_grey">
+                    Type in reason for the cancellation of the customer invoice
+                </p>
+                <group>
+                    <field name="cancel_reason_txt" required="1"/>
+                </group>
+                <footer>
+                    <button name="confirm_cancel"
+                        string="Confirm" type="object"
+                        class="oe_highlight"/>
+                    or
+                    <button string="Cancel" class="oe_link"
+                        special="cancel" />
+                </footer>
+            </form>
+            </field>
+        </record>
+
+        <record id="action_account_invoice_cancel" model="ir.actions.act_window">
+            <field name="name">Reason for the cancellation</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">account.invoice.cancel</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="view_account_invoice_cancel"/>
+            <field name="target">new</field>
+        </record>
+
+
+        <record id="view_account_voucher_cancel" model="ir.ui.view">
+            <field name="name">Reason for the cancellation</field>
+            <field name="model">account.voucher.cancel</field>
+            <field name="arch" type="xml">
+             <form string="Reason for the cancellation" version="7.0">
+                <p class="oe_grey">
+                    Type in reason for the cancellation of the voucher
+                </p>
+                <group>
+                    <field name="cancel_reason_txt" required="1"/>
+                </group>
+                <footer>
+                    <button name="confirm_cancel"
+                        string="Confirm" type="object"
+                        class="oe_highlight"/>
+                    or
+                    <button string="Cancel" class="oe_link"
+                        special="cancel" />
+                </footer>
+            </form>
+            </field>
+        </record>
+
+        <record id="action_voucher_cancel" model="ir.actions.act_window">
+            <field name="name">Reason for the cancellation</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">account.voucher.cancel</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="view_account_voucher_cancel"/>
+            <field name="target">new</field>
+        </record>
+    </data>
+</openerp>

--- a/hr_expense_advance_clearing/__init__.py
+++ b/hr_expense_advance_clearing/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import models
+from . import wizard

--- a/hr_expense_advance_clearing/__openerp__.py
+++ b/hr_expense_advance_clearing/__openerp__.py
@@ -20,10 +20,12 @@ HR Expense Advance Clearing
     "depends": [
         "hr_expense_sequence",
         "hr_expense_auto_invoice",
+        'account_cancel_with_reversal',
     ],
     "data": [
         'data/hr_expense_data.xml',
         'data/product_data.xml',
+        'data/invoice_workflow.xml',
         'views/hr_expense_view.xml',
         'views/account_invoice_view.xml',
     ],

--- a/hr_expense_advance_clearing/data/invoice_workflow.xml
+++ b/hr_expense_advance_clearing/data/invoice_workflow.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="t15_paid" model="workflow.transition">
+            <field name="act_from" ref="account.act_paid"/>
+            <field name="act_to" ref="account.act_cancel"/>
+            <field name="signal">clearing_invoice_cancel</field>
+        </record>
+    </data>
+</openerp>

--- a/hr_expense_advance_clearing/views/account_invoice_view.xml
+++ b/hr_expense_advance_clearing/views/account_invoice_view.xml
@@ -9,6 +9,20 @@
                 <xpath expr="//field[@name='check_total']" position="after">
                     <field name="is_advance_clearing" readonly="1"/>
                 </xpath>
+                <xpath expr="//button[@name='invoice_cancel']" position="after">
+                    <!--button name="clearing_invoice_cancel" 
+                            string="Cancel Invoice"
+                            type="workflow"
+                            attrs="{'invisible': ['|', ('state', '!=', 'paid'),('is_advance_clearing', '=', False)]}"
+                            groups="account.group_account_invoice"/-->
+                    <button name="%(account_cancel_with_reversal.act_account_move_reverse_invoice)d" 
+                            type="action" 
+                            string="Cancel Invoice"
+                            attrs="{'invisible': ['|', ('state', '!=', 'paid'),('is_advance_clearing', '=', False)]}"
+                            class="oe_highlight" 
+                            states="open" 
+                    />
+                </xpath>
             </field>
         </record>
     </data>

--- a/hr_expense_advance_clearing/wizard/__init__.py
+++ b/hr_expense_advance_clearing/wizard/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import account_move_reverse

--- a/hr_expense_advance_clearing/wizard/account_move_reverse.py
+++ b/hr_expense_advance_clearing/wizard/account_move_reverse.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from openerp import models, api
+
+
+class AccountMoveReversal(models.TransientModel):
+    _inherit = "account.move.reverse"
+    _description = "Create reversal of account moves"
+
+    @api.multi
+    def action_reverse_invoice(self):
+        res = super(AccountMoveReversal, self).action_reverse_invoice()
+        assert 'active_ids' in self.env.context, "active_ids \
+                                        missing in context"
+        invoice_ids = self.env.context['active_ids']
+        invoices = self.env['account.invoice'].browse(invoice_ids)
+        for invoice in invoices:
+            # first call super call if invoice is clearing then it is
+            # not able to cancel invoice from paid state
+            # so we made new transition for paid invoice to cancel invoice
+            if invoice.is_advance_clearing:
+                invoice.signal_workflow('clearing_invoice_cancel')
+        return res


### PR DESCRIPTION
Hi Kitti,

Ref: /issues/657

For Case: Clearing, we face some problem here,
    As validating Clearing Invoice already auto reconcile and Paid, as such,
    Cancel button is invisible -> can we fix this by make it visible for Advance Clearing case?

We have visible cancel button on paid state and allow user to create reversal move + reason (Only for clearing invoice.).

Thanks,
Mustufa