### PR TITLE
[ADD/FIX]account_invoice_type: added new module to add new field invo…

### DIFF
--- a/account_invoice_type/__init__.py
+++ b/account_invoice_type/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import models
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_invoice_type/__openerp__.py
+++ b/account_invoice_type/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': "Account Invoice Type",
+    'summary': "Added new invoice_type field on invoice",
+    'author': "Ecosoft",
+    'website': "http://ecosoft.co.th",
+    'category': 'Account',
+    'version': '0.1.0',
+    'depends': [
+        'account',
+    ],
+    'data': [
+        'views/account_invoice_view.xml',
+    ],
+    'demo': [
+    ],
+    'installable': True,
+}
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_invoice_type/models/__init__.py
+++ b/account_invoice_type/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import account_invoice
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_invoice_type/models/account_invoice.py
+++ b/account_invoice_type/models/account_invoice.py
@@ -1,0 +1,12 @@
+from openerp import models, fields, api, _
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    invoice_type = fields.Selection(
+        [('normal', 'Normal Invoice')],
+        string="Invoice Type",
+        readonly=True,
+        default='normal',
+    )

--- a/account_invoice_type/views/account_invoice_view.xml
+++ b/account_invoice_type/views/account_invoice_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="invoice_supplier_form" model="ir.ui.view">
+            <field name="name">account.invoice.supplier.form</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='check_total']" position="after">
+                    <field name="invoice_type"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/hr_expense_advance_clearing/__openerp__.py
+++ b/hr_expense_advance_clearing/__openerp__.py
@@ -18,6 +18,7 @@ HR Expense Advance Clearing
     "application": False,
     "installable": True,
     "depends": [
+        'account_invoice_type',
         "hr_expense_sequence",
         "hr_expense_auto_invoice",
         'account_cancel_with_reversal',

--- a/hr_expense_advance_clearing/models/account_invoice.py
+++ b/hr_expense_advance_clearing/models/account_invoice.py
@@ -11,6 +11,12 @@ class AccountInvoice(models.Model):
     is_advance_clearing = fields.Boolean(
         string='Advance Clearing?',
     )
+    invoice_type = fields.Selection(
+        selection_add=[
+            ('expense_advance_invoice', 'Employee Advance Invoice'),
+            ('advance_clearing_invoice', 'Advance Clearing Invoice'),
+        ],
+    )
 
     @api.model
     def _get_invoice_total(self, invoice):
@@ -31,7 +37,9 @@ class AccountInvoice(models.Model):
     def invoice_validate(self):
         result = super(AccountInvoice, self).invoice_validate()
         for invoice in self:
-            if invoice.is_advance_clearing and not invoice.amount_total:
+#             if invoice.is_advance_clearing and not invoice.amount_total:
+            if invoice.invoice_type == 'advance_clearing_invoice'\
+                    and not invoice.amount_total:
                 move_lines = \
                     self.env['account.move.line'].search(
                         [('state', '=', 'valid'),

--- a/hr_expense_advance_clearing/models/hr_expense.py
+++ b/hr_expense_advance_clearing/models/hr_expense.py
@@ -169,7 +169,10 @@ class HRExpenseExpense(models.Model):
             advance_line.copy({'invoice_id': invoice.id,
                                'price_unit': -employee_advance,
                                'sequence': 1, })
-            invoice.write({'is_advance_clearing': True})
+            invoice.write({'is_advance_clearing': True,
+                           'invoice_type': 'advance_clearing_invoice'})
+        elif expense.is_employee_advance:
+            invoice.write({'invoice_type': 'expense_advance_invoice'})
         return invoice
 
     @api.model

--- a/hr_expense_advance_clearing/views/account_invoice_view.xml
+++ b/hr_expense_advance_clearing/views/account_invoice_view.xml
@@ -16,9 +16,10 @@
                             attrs="{'invisible': ['|', ('state', '!=', 'paid'),('is_advance_clearing', '=', False)]}"
                             groups="account.group_account_invoice"/-->
                     <button name="%(account_cancel_with_reversal.act_account_move_reverse_invoice)d" 
-                            type="action" 
+                            type="action"
                             string="Cancel Invoice"
-                            attrs="{'invisible': ['|', ('state', '!=', 'paid'),('is_advance_clearing', '=', False)]}"
+                            attrs="{'invisible': ['|', ('state', '!=', 'paid'),
+                                                       ('invoice_type', 'not in', ('expense_advance_invoice', 'advance_clearing_invoice'))]}"
                             class="oe_highlight" 
                     />
                 </xpath>

--- a/hr_expense_advance_clearing/wizard/account_move_reverse.py
+++ b/hr_expense_advance_clearing/wizard/account_move_reverse.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from openerp import models, api
+from openerp import models, api, _
+from openerp.exceptions import Warning as UserError
 
 
 class AccountMoveReversal(models.TransientModel):
@@ -8,15 +9,25 @@ class AccountMoveReversal(models.TransientModel):
 
     @api.multi
     def action_reverse_invoice(self):
-        res = super(AccountMoveReversal, self).action_reverse_invoice()
         assert 'active_ids' in self.env.context, "active_ids \
                                         missing in context"
         invoice_ids = self.env.context['active_ids']
         invoices = self.env['account.invoice'].browse(invoice_ids)
         for invoice in invoices:
+            if invoice.invoice_type == 'expense_advance_invoice':
+                if invoice.expense_id.advance_clearing_ids:
+                    raise UserError(_('Sorry!, \
+                        You can not cancel employee advance \
+                        invoice since it has already\
+                        clearing advance invoices.'))
+        res = super(AccountMoveReversal, self).action_reverse_invoice()
+        for invoice in invoices:
             # first call super call if invoice is clearing then it is
             # not able to cancel invoice from paid state
             # so we made new transition for paid invoice to cancel invoice
-            if invoice.is_advance_clearing:
+            # if invoice.is_advance_clearing:
+            if invoice.invoice_type == 'advance_clearing_invoice':
+                invoice.signal_workflow('clearing_invoice_cancel')
+            elif invoice.invoice_type == 'expense_advance_invoice':
                 invoice.signal_workflow('clearing_invoice_cancel')
         return res


### PR DESCRIPTION
Hi Kitti,

Ref: /issues/657#note-8

TODO:
Error when running cancel invoice for advance invoice form (In case of advance invoice is paid) --> ('You have to provide an account for the write off/exchange difference entry.'))
We have found that if we unreconcile entries manually for advance invoice then we will get out from above error.

Besides we have added new module account_invoice_type which will be used now to identify source of invoice (Instead of using checkboxes!).

Regards,
Mustufa

