### PR TITLE
[ADD]multi_lang_search: Ability to search by data in any language - r…

### DIFF
--- a/multi_lang_search/__init__.py
+++ b/multi_lang_search/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/multi_lang_search/__openerp__.py
+++ b/multi_lang_search/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': "Multi Language Search",
+    'version': '0.1',
+    'category': 'Uncategorized',
+    'description': """
+Allows to search record in multi language inputs.
+""",
+    'author': "Kitti U.",
+    'website': 'http://ecosoft.co.th',
+    'license': 'AGPL-3',
+    "depends": ['base'],
+    "data": [
+    ],
+    'test': [
+    ],
+    "demo": [],
+    "active": True,
+    "installable": True,
+}

--- a/multi_lang_search/models/__init__.py
+++ b/multi_lang_search/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import object
+from . import partner

--- a/multi_lang_search/models/object.py
+++ b/multi_lang_search/models/object.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from openerp.models import BaseModel
+from openerp import api
+
+_logger = logging.getLogger(__name__)
+
+
+@api.model
+def name_search(self, name='', args=None, operator='ilike', limit=100):
+    result = self._name_search(name, args, operator, limit=limit)
+    if not result:
+        trans_name = '%s,%s' % (self._model, 'name')
+        translation_ids =\
+            self.env['ir.translation'].search([('value', 'ilike', name),
+                                               ('name', '=', trans_name)],
+                                              limit=limit)
+        record_ids = [t.res_id for t in translation_ids]
+        record_ids = self.browse(record_ids)
+        disp = ''
+        for rec in record_ids:
+            if rec:
+                disp = str(rec.name)
+                result.append((rec.id, disp))
+    return result
+
+BaseModel.name_search = name_search

--- a/multi_lang_search/models/partner.py
+++ b/multi_lang_search/models/partner.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models
+from openerp.osv.expression import get_unaccent_wrapper
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    def name_search(self, cr, uid, name, args=None,
+                    operator='ilike', context=None, limit=100):
+        if not args:
+            args = []
+        if name and operator in ('=', 'ilike', '=ilike', 'like', '=like'):
+
+            self.check_access_rights(cr, uid, 'read')
+            where_query = self._where_calc(cr, uid, args, context=context)
+            self._apply_ir_rules(cr, uid, where_query, 'read', context=context)
+            from_clause, where_clause, where_clause_params =\
+                where_query.get_sql()
+            where_str =\
+                where_clause and (" WHERE %s AND " % where_clause) or ' WHERE '
+
+            # search on the name of the contacts and of its company
+            search_name = name
+            if operator in ('ilike', 'like'):
+                search_name = '%%%s%%' % name
+            if operator in ('=ilike', '=like'):
+                operator = operator[1:]
+
+            unaccent = get_unaccent_wrapper(cr)
+
+            query = """SELECT id
+                         FROM res_partner
+                      {where} ({email} {operator} {percent}
+                           OR {display_name} {operator} {percent})
+                     ORDER BY {display_name}
+                    """.format(where=where_str, operator=operator,
+                               email=unaccent('email'),
+                               display_name=unaccent('display_name'),
+                               percent=unaccent('%s'))
+
+            where_clause_params += [search_name, search_name]
+            if limit:
+                query += ' limit %s'
+                where_clause_params.append(limit)
+            cr.execute(query, where_clause_params)
+            ids = map(lambda x: x[0], cr.fetchall())
+            # patch for record from translation
+            translation_obj = self.pool.get('ir.translation')
+            trans_name = '%s,%s' % (self._model, 'name')
+            translation_ids =\
+                translation_obj.search(cr, uid, [('value', 'ilike', name),
+                                                 ('name', '=', trans_name)],
+                                       limit=limit, context=context)
+            translations = translation_obj.browse(cr, uid,
+                                                  translation_ids,
+                                                  context=context)
+            record_ids = [t.res_id for t in translations]
+            ids = list(set(ids) | set(record_ids))
+            # patch over
+            if ids:
+                return self.name_get(cr, uid, ids, context)
+            else:
+                return []
+        return super(ResPartner, self).name_search(cr, uid, name, args,
+                                                   operator=operator,
+                                                   context=context,
+                                                   limit=limit)


### PR DESCRIPTION
Hi Kitti,

Ref: /issues/934

We have tried to make it generic for all name-search but please note that some modules fully override name-search method and so it does not call _name_search in ORM so for those object (partner, product, etc) we have to manually override in our module and fix for translation.  

We have given one example for partner object.

Thanks,
Mustufa